### PR TITLE
Feature/admin access category

### DIFF
--- a/app/controllers/admin_backoffice/categories_controller.rb
+++ b/app/controllers/admin_backoffice/categories_controller.rb
@@ -8,10 +8,34 @@ class AdminBackoffice::CategoriesController < AdminBackofficeController
   end
 
   def create
-    @category = Category.new(params.require(:category).permit(:name, :discount))
+    @category = Category.new(category_params)
 
-    if @category.save!
-      redirect_to admin_backoffice_categories_path, notice: I18n.t(:success)
+    if @category.save
+      redirect_to admin_backoffice_categories_path, notice: I18n.t(:create_success)
+    else
+      flash.now[:notice] = I18n.t(:create_fail)
+      render 'new'
     end
+  end
+
+  def edit
+    @category = Category.find(params[:id])
+  end
+
+  def update
+    @category = Category.find(params[:id])
+
+    if @category.update(category_params)
+      redirect_to admin_backoffice_categories_path, notice: I18n.t(:update_success)
+    else
+      flash.now[:notice] = I18n.t(:update_fail)
+      render 'edit'
+    end
+  end
+
+  private
+
+  def category_params
+    category_params = params.require(:category).permit(:name, :discount)
   end
 end

--- a/app/controllers/admin_backoffice/categories_controller.rb
+++ b/app/controllers/admin_backoffice/categories_controller.rb
@@ -1,0 +1,17 @@
+class AdminBackoffice::CategoriesController < AdminBackofficeController
+  def index
+    @categories = Category.all
+  end
+
+  def new
+    @category = Category.new
+  end
+
+  def create
+    @category = Category.new(params.require(:category).permit(:name, :discount))
+
+    if @category.save!
+      redirect_to admin_backoffice_categories_path, notice: I18n.t(:success)
+    end
+  end
+end

--- a/app/controllers/admin_backoffice/currencies_controller.rb
+++ b/app/controllers/admin_backoffice/currencies_controller.rb
@@ -15,7 +15,7 @@ class AdminBackoffice::CurrenciesController < AdminBackofficeController
     @admin = current_admin
     @currency = Currency.new(params.require(:currency).permit(:currency_value).merge(admin_id: @admin.id))
 
-    @currency.save!
+    @currency.save
     redirect_to admin_backoffice_currencies_path, notice: 'Taxa de Câmbio criada com sucesso.'
   end
 

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,0 +1,2 @@
+class Category < ApplicationRecord
+end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,5 +1,6 @@
 class Category < ApplicationRecord
   validates :name, presence: true
+  validates :name, uniqueness: true
   validates :name, length: { minimum: 3 }
 
   validates :discount, presence: true

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,2 +1,7 @@
 class Category < ApplicationRecord
+  validates :name, presence: true
+  validates :name, length: { minimum: 3 }
+
+  validates :discount, presence: true
+  validates :discount, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
 end

--- a/app/views/admin_backoffice/categories/edit.html.erb
+++ b/app/views/admin_backoffice/categories/edit.html.erb
@@ -1,4 +1,4 @@
-<h3>Cadastre nova categoria</h3>
+<h3>Editar <%= @category.name %></h3>
 
 <% if @category.errors.any? %>
   <p>Verifique os erros abaixo</p>
@@ -19,6 +19,6 @@
     <%= form.number_field :discount %>
   </div>
   <div>
-    <%= form.submit 'Registrar' %>
+    <%= form.submit 'Salvar' %>
   <div>
 <% end %>

--- a/app/views/admin_backoffice/categories/edit.html.erb
+++ b/app/views/admin_backoffice/categories/edit.html.erb
@@ -1,4 +1,4 @@
-<h3>Editar <%= @category.name %></h3>
+<h3>Editar Categoria</h3>
 
 <% if @category.errors.any? %>
   <p>Verifique os erros abaixo</p>

--- a/app/views/admin_backoffice/categories/index.html.erb
+++ b/app/views/admin_backoffice/categories/index.html.erb
@@ -1,0 +1,15 @@
+<h3>Categorias Cadastradas</h3>
+
+<div class="links">
+  <%= link_to 'Adicionar nova categoria', new_admin_backoffice_category_path %>
+</div>
+
+<div>
+  <% if @categories.empty? %>
+    <p>Não há categorias cadastradas</p>
+  <% end %>
+  <% @categories.each do |category| %>
+    <p>Categoria: <%= category.name %></p>
+    <p>Taxa de Desconto: <%= category.discount %>%</p>
+  <% end %>
+</div>

--- a/app/views/admin_backoffice/categories/index.html.erb
+++ b/app/views/admin_backoffice/categories/index.html.erb
@@ -9,7 +9,10 @@
     <p>Não há categorias cadastradas</p>
   <% end %>
   <% @categories.each do |category| %>
-    <p>Categoria: <%= category.name %></p>
-    <p>Taxa de Desconto: <%= category.discount %>%</p>
+    <div class="<%= category.name.parameterize.underscore %>">
+      <p>Categoria: <%= category.name %></p>
+      <p>Taxa de Desconto: <%= category.discount %>%</p>
+      <%= link_to I18n.t(:edit), edit_admin_backoffice_category_path(category.id) %>
+    </div>
   <% end %>
 </div>

--- a/app/views/admin_backoffice/categories/new.html.erb
+++ b/app/views/admin_backoffice/categories/new.html.erb
@@ -1,0 +1,15 @@
+<h3>Cadastre nova categoria</h3>
+
+<%= form_with(model: [:admin_backoffice, @category]) do |form| %>
+  <div>
+    <%= form.label :name %>
+    <%= form.text_field :name %>
+  </div>
+  <div>
+    <%= form.label :discount %>
+    <%= form.text_field :discount, placeholder: 'Caso o campo fique em branco o valor será 0' %>
+  </div>
+  <div>
+    <%= form.submit 'Registrar' %>
+  <div>
+<% end %>

--- a/app/views/admin_backoffice/currencies/index.html.erb
+++ b/app/views/admin_backoffice/currencies/index.html.erb
@@ -2,7 +2,7 @@
 
 <div>
   <% @currencies.each do |currency| %>
-    <div class="<% currency.status %>">
+    <div class="<%= currency.status %>">
       <% if currency.pending? %>
         <p>Taxa criada é 10% maior que a anterior. Esperando aprovação de outro administrador.</p>
       <% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -21,6 +21,7 @@
           <%= current_admin.email %> |
           <%= link_to 'Taxa de Câmbio', admin_backoffice_currencies_path %> |
           <%= link_to 'Cadastrar nova Taxa', new_admin_backoffice_currency_path %> |
+          <%= link_to 'Categorias',  admin_backoffice_categories_path %> |
           <%= button_to 'Sair', destroy_admin_session_path, method: :delete%>
         <% else %> 
           <%= link_to 'Entrar', new_admin_session_path %> |

--- a/config/locales/models/category.pt-BR.yml
+++ b/config/locales/models/category.pt-BR.yml
@@ -1,5 +1,9 @@
 pt-BR:
-  success: Categoria adicionada com sucesso.
+  create_success: Categoria adicionada com sucesso.
+  create_fail: Não foi possível criar a categoria.
+  update_success: Categoria adicionada com sucesso.
+  update_fail: Não foi possível atualizar a categoria.
+  edit: Editar
   activerecord:
     models:
       category: Categoria

--- a/config/locales/models/category.pt-BR.yml
+++ b/config/locales/models/category.pt-BR.yml
@@ -1,0 +1,9 @@
+pt-BR:
+  success: Categoria adicionada com sucesso.
+  activerecord:
+    models:
+      category: Categoria
+    attributes:
+      category:
+        name: Nome da categoria
+        discount: Taxa fixa de desconto

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,10 @@ Rails.application.routes.draw do
 
   namespace(:admin_backoffice) do
     resources :currencies, only: %i[index create new]
+    resources :categories, only: %i[index create new]
+
     get '/pending_admins', to: 'registered_admins#approval'
+
     resources :registered_admins do
       post 'approve', on: :member
       post 'refuse', on: :member

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,7 @@ Rails.application.routes.draw do
 
   namespace(:admin_backoffice) do
     resources :currencies, only: %i[index create new]
-    resources :categories, only: %i[index create new]
+    resources :categories, only: %i[index create new edit update]
 
     get '/pending_admins', to: 'registered_admins#approval'
 

--- a/db/migrate/20220614203419_create_categories.rb
+++ b/db/migrate/20220614203419_create_categories.rb
@@ -1,0 +1,10 @@
+class CreateCategories < ActiveRecord::Migration[7.0]
+  def change
+    create_table :categories do |t|
+      t.string :name
+      t.integer :discount, default: 0
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_06_13_200456) do
+ActiveRecord::Schema[7.0].define(version: 2022_06_14_203419) do
   create_table "admins", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
@@ -26,6 +26,13 @@ ActiveRecord::Schema[7.0].define(version: 2022_06_13_200456) do
     t.index ["admin_id"], name: "index_admins_on_admin_id"
     t.index ["email"], name: "index_admins_on_email", unique: true
     t.index ["reset_password_token"], name: "index_admins_on_reset_password_token", unique: true
+  end
+
+  create_table "categories", force: :cascade do |t|
+    t.string "name"
+    t.integer "discount", default: 0
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "currencies", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,3 +5,6 @@
 #
 #   movies = Movie.create([{ name: "Star Wars" }, { name: "Lord of the Rings" }])
 #   Character.create(name: "Luke", movie: movies.first)
+
+admin_ativo = Admin.create(name: 'Admin Genérico', email: 'admin@userubis.com.br', password: 'password', registration_number: '111.222.333-44', status: :active)
+admin_ativo_2 = Admin.create(name: 'Admin de Marca', email: 'admin2@userubis.com.br', password: 'password', registration_number: '222.442.333-44', status: :active)

--- a/spec/factories/categories.rb
+++ b/spec/factories/categories.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :category do
+    name { "MyString" }
+    discount { 1 }
+  end
+end

--- a/spec/factories/categories.rb
+++ b/spec/factories/categories.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :category do
-    name { "MyString" }
-    discount { 1 }
+    name { "VIP" }
+    discount { 10 }
   end
 end

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Category, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Category, type: :model do
     end
 
     context 'length' do
-      it 'nome tem pelo menos 5 letras' do
+      it 'nome tem pelo menos 3 letras' do
         expect(described_class.new).to validate_length_of(:name).is_at_least(3)
       end
     end

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -24,5 +24,11 @@ RSpec.describe Category, type: :model do
         expect(described_class.new).to validate_numericality_of(:discount).is_greater_than_or_equal_to(0)
       end
     end
+
+    context 'uniqueness' do
+      it 'nome da categoria é único' do
+        expect(described_class.new).to validate_uniqueness_of(:name)
+      end
+    end
   end
 end

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -1,5 +1,28 @@
 require 'rails_helper'
 
 RSpec.describe Category, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe '#valid?' do
+    context 'presence' do
+      it 'inválido quando o nome está em branco' do
+        expect(described_class.new).to validate_presence_of(:name)
+      end
+
+      it 'inválido quando a taxa de desconto estiver em branco' do
+        expect(described_class.new).to validate_presence_of(:discount)
+      end
+    end
+
+    context 'length' do
+      it 'nome tem pelo menos 5 letras' do
+        expect(described_class.new).to validate_length_of(:name).is_at_least(3)
+      end
+    end
+
+    context 'numericality' do
+      it 'desconto precisa ser integer e maior ou igual a 0' do
+        expect(described_class.new).to validate_numericality_of(:discount).only_integer
+        expect(described_class.new).to validate_numericality_of(:discount).is_greater_than_or_equal_to(0)
+      end
+    end
+  end
 end

--- a/spec/requests/categories/admin_edit_category_request_spec.rb
+++ b/spec/requests/categories/admin_edit_category_request_spec.rb
@@ -11,8 +11,18 @@ describe 'Administrador edita uma categoria' do
     expect(response).to redirect_to(admin_backoffice_categories_path)
   end
 
-  it 'sem estar autenticado' do
-    admin = create(:admin)
+  it 'enquanto o seu cadastro ainda esta pendente' do
+    admin = create(:admin, status: :pending)
+    categoria = create(:category)
+
+    login_as(admin)
+    patch(admin_backoffice_category_path(categoria.id), params: { category: { name: 'Padrão', discount: 0 } })
+
+    expect(response).to redirect_to(new_admin_session_path)
+  end
+
+  it 'enquanto o seu cadastro esta inativo' do
+    admin = create(:admin, status: :inactive)
     categoria = create(:category)
 
     login_as(admin)

--- a/spec/requests/categories/admin_edit_category_request_spec.rb
+++ b/spec/requests/categories/admin_edit_category_request_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+describe 'Administrador edita uma categoria' do
+  it 'com sucesso' do
+    admin = create(:admin, status: :active)
+    categoria = create(:category)
+
+    login_as(admin)
+    patch(admin_backoffice_category_path(categoria.id), params: { category: { name: 'Padrão', discount: 0 } })
+
+    expect(response).to redirect_to(admin_backoffice_categories_path)
+  end
+
+  it 'sem estar autenticado' do
+    admin = create(:admin)
+    categoria = create(:category)
+
+    login_as(admin)
+    patch(admin_backoffice_category_path(categoria.id), params: { category: { name: 'Padrão', discount: 0 } })
+
+    expect(response).to redirect_to(new_admin_session_path)
+  end
+
+  it 'sem estar logado' do
+    categoria = create(:category)
+
+    patch(admin_backoffice_category_path(categoria.id), params: { category: { name: 'Padrão', discount: 0 } })
+
+    expect(response).to redirect_to(new_admin_session_path)
+  end
+end

--- a/spec/system/categories/admin_edits_category_spec.rb
+++ b/spec/system/categories/admin_edits_category_spec.rb
@@ -38,4 +38,23 @@ describe 'Administrador edita uma categoria existente' do
     expect(page).to have_content('Não foi possível atualizar a categoria.')
     expect(page).to have_content('Nome da categoria não pode ficar em branco')
   end
+
+  it 'nome da categoria duplicada' do
+    admin = create(:admin, status: :active)
+    category = create(:category)
+    other_category = create(:category, name: 'Não VIP')
+
+    login_as(admin)
+    visit root_path
+    click_on 'Categorias'
+    within(".#{other_category.name.parameterize.underscore}") do
+      click_on 'Editar'
+    end
+    fill_in 'Nome da categoria', with: 'VIP'
+    fill_in 'Taxa fixa de desconto', with: 30
+    click_on 'Salvar'
+
+    expect(page).to have_content('Não foi possível atualizar a categoria.')
+    expect(page).to have_content('Nome da categoria já está em uso')
+  end
 end

--- a/spec/system/categories/admin_edits_category_spec.rb
+++ b/spec/system/categories/admin_edits_category_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+describe 'Administrador edita uma categoria existente' do
+  it 'com sucesso' do
+    admin = create(:admin, status: :active)
+    category = create(:category)
+    other_category = create(:category, name: 'Não VIP')
+
+    login_as(admin)
+    visit root_path
+    click_on 'Categorias'
+    within(".#{category.name.parameterize.underscore}") do
+      click_on 'Editar'
+    end
+    fill_in 'Nome da categoria', with: 'Super VIP'
+    fill_in 'Taxa fixa de desconto', with: 30
+    click_on 'Salvar'
+
+    expect(page).to have_content('Categoria: Super VIP')
+    expect(page).to have_content('Taxa de Desconto: 30%')
+  end
+
+  it 'com dados inválidos' do
+    admin = create(:admin, status: :active)
+    category = create(:category)
+    other_category = create(:category, name: 'Não VIP')
+
+    login_as(admin)
+    visit root_path
+    click_on 'Categorias'
+    within(".#{category.name.parameterize.underscore}") do
+      click_on 'Editar'
+    end
+    fill_in 'Nome da categoria', with: ''
+    fill_in 'Taxa fixa de desconto', with: 30
+    click_on 'Salvar'
+
+    expect(page).to have_content('Não foi possível atualizar a categoria.')
+    expect(page).to have_content('Nome da categoria não pode ficar em branco')
+  end
+end

--- a/spec/system/categories/admin_edits_category_spec.rb
+++ b/spec/system/categories/admin_edits_category_spec.rb
@@ -57,4 +57,34 @@ describe 'Administrador edita uma categoria existente' do
     expect(page).to have_content('Não foi possível atualizar a categoria.')
     expect(page).to have_content('Nome da categoria já está em uso')
   end
+
+  it 'enquanto o seu status é inativo' do
+    admin = create(:admin, status: :inactive)
+    category = create(:category)
+    other_category = create(:category, name: 'Outra Categoria')
+
+    login_as(admin)
+    visit edit_admin_backoffice_category_path(category.id)
+
+    expect(page).to have_current_path(new_admin_session_path)
+  end
+
+  it 'enquanto o seu status é pendente' do
+    admin = create(:admin, status: :pending)
+    category = create(:category)
+    other_category = create(:category, name: 'Outra Categoria')
+
+    login_as(admin)
+    visit edit_admin_backoffice_category_path(category.id)
+
+    expect(page).to have_current_path(new_admin_session_path)
+  end
+
+  it 'e não está logado' do
+    category = create(:category)
+
+    visit edit_admin_backoffice_category_path(category.id)
+
+    expect(page).to have_current_path(new_admin_session_path)
+  end
 end

--- a/spec/system/categories/admin_registers_new_category_spec.rb
+++ b/spec/system/categories/admin_registers_new_category_spec.rb
@@ -33,4 +33,28 @@ describe 'Administrador cadastra categoria de cliente nova' do
     expect(page).to have_content('Verifique os erros abaixo')
     expect(page).to have_content('Nome da categoria não pode ficar em branco')
   end
+
+  it 'enquanto seu status está pendente' do
+    admin = create(:admin, status: :pending)
+
+    login_as(admin)
+    visit new_admin_backoffice_category_path
+
+    expect(page).to have_current_path(new_admin_session_path)
+  end
+
+  it 'enquanto seu status está inativo' do
+    admin = create(:admin, status: :inactive)
+
+    login_as(admin)
+    visit new_admin_backoffice_category_path
+
+    expect(page).to have_current_path(new_admin_session_path)
+  end
+  
+  it 'e não está logado' do
+    visit new_admin_backoffice_category_path
+
+    expect(page).to have_current_path(new_admin_session_path)
+  end
 end

--- a/spec/system/categories/admin_registers_new_category_spec.rb
+++ b/spec/system/categories/admin_registers_new_category_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+describe 'Administrador cadastra categoria de cliente nova' do
+  it 'com sucesso' do
+    admin = create(:admin, status: :active)
+
+    login_as(admin)
+    visit root_path
+
+    click_on 'Categorias'
+    click_on 'Adicionar nova categoria'
+
+    fill_in 'Nome da categoria', with: 'Genérica'
+    fill_in 'Taxa fixa de desconto', with: 3
+    click_on 'Registrar'
+
+    expect(page).to have_content('Categoria adicionada com sucesso.')
+    expect(page).to have_content('Categoria: Genérica')
+    expect(page).to have_content('Taxa de Desconto: 3%')
+  end
+end

--- a/spec/system/categories/admin_registers_new_category_spec.rb
+++ b/spec/system/categories/admin_registers_new_category_spec.rb
@@ -18,4 +18,19 @@ describe 'Administrador cadastra categoria de cliente nova' do
     expect(page).to have_content('Categoria: Genérica')
     expect(page).to have_content('Taxa de Desconto: 3%')
   end
+
+  it 'com informações inválidas' do
+    admin = create(:admin, status: :active)
+
+    login_as(admin)
+    visit new_admin_backoffice_category_path
+
+    fill_in 'Nome da categoria', with: ''
+    fill_in 'Taxa fixa de desconto', with: 3
+    click_on 'Registrar'
+
+    expect(page).to have_content('Não foi possível criar a categoria')
+    expect(page).to have_content('Verifique os erros abaixo')
+    expect(page).to have_content('Nome da categoria não pode ficar em branco')
+  end
 end


### PR DESCRIPTION
#15 

Foram adicionados dois administradores ativos no arquivo seeds.rb, além da funcionalidade de cadastro de categorias de cliente. Cada categoria deve ter obrigatoriamente um nome único e uma taxa de desconto que tem 0 por padrão. É possível criar e editar uma nova categoria. Essa categoria ainda terá, posteriormente, uma conversão bônus, que será criada em outra issue.

![categoria1](https://user-images.githubusercontent.com/85138641/173913146-7b0f8e6a-0709-42b1-8a1b-506a9e811fa2.png)

![categoria2](https://user-images.githubusercontent.com/85138641/173913514-63bc1427-9cfa-4df8-956b-95ff00dce66e.png)

Obs: os formulários de criação e edição são iguais.




