### PR TITLE
Corrige bug na área de taxa de conversão

### DIFF
--- a/app/controllers/admin_backoffice/currencies_controller.rb
+++ b/app/controllers/admin_backoffice/currencies_controller.rb
@@ -1,6 +1,7 @@
 class AdminBackoffice::CurrenciesController < AdminBackofficeController
   before_action :authorize_active_admin
   before_action :set_inactive_if_3_days_ago
+  before_action :check_pending, only: [:new, :create]
 
   def index
     @currencies = Currency.all.order(created_at: :desc)
@@ -42,7 +43,15 @@ class AdminBackoffice::CurrenciesController < AdminBackofficeController
   end
 
   def set_inactive_if_3_days_ago
-    @currency = Currency.last
-    @currency.inactive! if !@currency.nil? && @currency.created_at.to_date < 3.days.ago
+    @currencies = Currency.active
+    @currencies.each do |currency|
+      currency.inactive! if !currency.nil? && currency.created_at.to_date < 3.days.ago
+    end
+  end
+
+  def check_pending
+    if Currency.pending.any?
+      redirect_to admin_backoffice_currencies_path, notice: 'Não pode ser criada nova taxa enquanto tiver uma pendente.'
+    end
   end
 end

--- a/app/models/currency.rb
+++ b/app/models/currency.rb
@@ -18,10 +18,13 @@ class Currency < ApplicationRecord
     end
   end
 
-  def set_pending 
-    @currency = Currency.last(2)
-    if !@currency[1].nil? && (@currency[0].currency_value + @currency[0].currency_value * 0.1) < @currency[1].currency_value
-      self.pending!
+  def set_pending
+    if Currency.all.count >= 2
+      @currencies = Currency.last(2)
+      if (@currencies[0].currency_value + @currencies[0].currency_value * 0.1) < @currencies[1].currency_value
+        self.pending!
+        @currencies[0].active!
+      end
     end
   end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,14 +13,16 @@
   <body>
     <header>
       <div>
-        <h1>Pagamentos</h1>
+        <h1><%= link_to 'Pagamentos', root_path %></h1>
       </div>
       <nav>
         <% if admin_signed_in? %>
           <%= current_admin.name %> | 
           <%= current_admin.email %> |
           <%= link_to 'Taxa de Câmbio', admin_backoffice_currencies_path %> |
-          <%= link_to 'Cadastrar nova Taxa', new_admin_backoffice_currency_path %> |
+          <% if Currency.pending.empty? %>
+            <%= link_to 'Cadastrar nova Taxa', new_admin_backoffice_currency_path %> |
+          <% end %>
           <%= link_to 'Categorias',  admin_backoffice_categories_path %> |
           <%= button_to 'Sair', destroy_admin_session_path, method: :delete%>
         <% else %> 

--- a/spec/requests/currencies/admin_register_category_spec.rb
+++ b/spec/requests/currencies/admin_register_category_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+describe 'Administrador cria uma categoria' do
+  it 'enquanto há outra pendente' do
+    admin = create(:admin, status: :active)
+    create(:currency)
+    create(:currency, currency_value: 2)
+
+    login_as(admin)
+    post(admin_backoffice_currencies_path, params: { currency: { currency_value: 3, admin: admin } })
+
+    expect(response).to redirect_to(admin_backoffice_currencies_path)
+  end
+end

--- a/spec/system/authentication/admin_access_plataform_spec.rb
+++ b/spec/system/authentication/admin_access_plataform_spec.rb
@@ -17,6 +17,7 @@ describe 'Administrador ativo acessa a plataforma' do
     end
 
     expect(page).to have_current_path root_path
+    expect(page).to have_link('Pagamentos')
   end
 
   it 'e faz logout' do

--- a/spec/system/money_conversion/admin_register_money_conversion_spec.rb
+++ b/spec/system/money_conversion/admin_register_money_conversion_spec.rb
@@ -72,4 +72,18 @@ describe 'Administrador cadastra uma taxa de câmbio' do
     expect(page).to have_content 'Usuário Responsável: Admin de Solza'
     expect(page).to have_content 'Status: pending'
   end
+
+  it 'e cria uma taxa enquanto outra estiver pendente' do
+    admin = create(:admin)
+    admin.active!
+    create(:currency)
+    create(:currency, currency_value: 3)
+
+    login_as(admin)
+    visit root_path
+    click_on 'Taxa de Câmbio'
+
+    expect(page).not_to have_link 'Cadastrar nova Taxa'
+    expect(page).to have_content 'Status: pending'
+  end
 end


### PR DESCRIPTION
Corrige erro na lógica de criação de novas taxas. Era possível criar uma taxa 10% maior que a última ativa criando duas em sequência (a primeira viria como pendente por ultrapassar os 10% de aumento, mas a segunda seria criada como ativa pois estaria sendo comparada à essa pendente e não à última taxa válida). Foi resolvido bloqueando a criação de novas taxas enquanto houverem taxas pendentes para aprovação.

Co-authored-by: Lucas Eduardo Campolino <Campolino@users.noreply.github.com>