### PR TITLE
Feature/admin rejects currency

### DIFF
--- a/app/controllers/admin_backoffice/currencies_controller.rb
+++ b/app/controllers/admin_backoffice/currencies_controller.rb
@@ -22,7 +22,6 @@ class AdminBackoffice::CurrenciesController < AdminBackofficeController
 
   def approve
     @currency = Currency.find(params[:id])
-
     if current_admin.id == @currency.admin_id
       redirect_to admin_backoffice_currencies_path,
                   notice: 'Você não pode aprovar essa taxa, solicite a outro administrador.'
@@ -32,6 +31,12 @@ class AdminBackoffice::CurrenciesController < AdminBackofficeController
       @currencies.first.inactive!
       redirect_to admin_backoffice_currencies_path, notice: 'Taxa aprovada com sucesso!'
     end
+  end
+
+  def reject
+    @currency = Currency.find(params[:id])
+    @currency.inactive!
+    redirect_to admin_backoffice_currencies_path, notice: 'Taxa rejeitada com sucesso!'
   end
 
   private

--- a/app/controllers/api/v1/api_controller.rb
+++ b/app/controllers/api/v1/api_controller.rb
@@ -5,10 +5,10 @@ class Api::V1::ApiController < ActionController::API
   private
 
   def return_status_500
-    render status: :internal_server_error, plain: 'Error'
+    head 500
   end
 
   def return_status_404
-    render status: 404, plain: 'Não existe esse cliente.'
+    head 404
   end
 end

--- a/app/models/client_wallet.rb
+++ b/app/models/client_wallet.rb
@@ -1,6 +1,7 @@
 class ClientWallet < ApplicationRecord
   belongs_to :category, optional: true
-
+  
+  validates :registered_number, :email, uniqueness: true
   validates :registered_number, :email, :balance, :bonus_balance, presence: true
   validates :balance, :bonus_balance, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
   validates :email, format: { with: /\A(|(([A-Za-z0-9]+_+)|([A-Za-z0-9]+\-+)|([A-Za-z0-9]+\.+)|([A-Za-z0-9]+\++))*[A-Za-z0-9]+@((\w+\-+)|(\w+\.))*\w{1,63}\.[a-zA-Z]{2,6})\z/ }

--- a/app/views/admin_backoffice/currencies/index.html.erb
+++ b/app/views/admin_backoffice/currencies/index.html.erb
@@ -6,6 +6,7 @@
       <% if currency.pending? %>
         <p>Taxa criada é 10% maior que a anterior. Esperando aprovação de outro administrador.</p>
         <%= button_to 'Aprovar taxa', approve_admin_backoffice_currency_path(currency) %>
+        <%= button_to 'Rejeitar taxa', reject_admin_backoffice_currency_path(currency) %>
       <% end %>
       <p>Valor de um Rubi é <%= currency.currency_value %> Reais</p>
       <p>Usuário Responsável: <%= currency.admin.name %></p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
     resources :client_wallets
     resources :currencies, only: %i[index create new] do
       post 'approve', on: :member
+      post 'reject', on: :member
     end
     resources :categories, only: %i[index create new edit update]
     get '/pending_admins', to: 'registered_admins#approval'

--- a/spec/requests/apis/client_wallet/client_wallet_spec.rb
+++ b/spec/requests/apis/client_wallet/client_wallet_spec.rb
@@ -20,6 +20,18 @@ describe 'Wallet Client API' do
       expect(response.body).to include 'E-mail não pode ficar em branco'
       expect(response.body).to include 'CPF ou CNPJ não é válido'
     end
+
+    it 'com um cliente que já existe' do
+      create(:client_wallet)
+      wallet_params = { client_wallet: { registered_number: '111.111.111-11', email: 'teste@email.com' } }
+
+      post '/api/v1/client_wallets', params: wallet_params
+
+      expect(response).to have_http_status(412)
+      expect(response.body).to include 'E-mail já está em uso'
+      expect(response.body).to include 'CPF ou CNPJ já está em uso'
+    end
+
   end
 
   context 'GET /api/v1/client_wallet/balance' do

--- a/spec/requests/currencies/admin_register_currency_spec.rb
+++ b/spec/requests/currencies/admin_register_currency_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe 'Administrador cria uma categoria' do
+describe 'Administrador cria uma nova taxa' do
   it 'enquanto há outra pendente' do
     admin = create(:admin, status: :active)
     create(:currency)

--- a/spec/system/money_conversion/admin_rejects_pending_currency_spec.rb
+++ b/spec/system/money_conversion/admin_rejects_pending_currency_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+describe 'Administrador rejeita taxa de conversão' do
+  it 'com sucesso' do 
+    first_admin = create(:admin, status: :active)
+    second_admin = Admin.create!(name: 'Main Admin', registration_number: '33333333333',
+                                 email: 'mainadmin@userubis.com.br', password: 'password', status: :active)
+
+    create(:currency)
+    second_currency = Currency.create!(currency_value: 4, admin: first_admin)
+
+    login_as(second_admin)
+    visit(root_path)
+    click_on 'Taxa de Câmbio'
+    click_on 'Rejeitar taxa'
+    second_currency.reload
+
+    expect(page).to have_current_path(admin_backoffice_currencies_path, ignore_query: true)
+    expect(page).to have_content('Taxa rejeitada com sucesso!')
+    expect(second_currency.status).to eq('inactive')
+  end
+end


### PR DESCRIPTION
Adiciona botão de rejeitar taxa de conversão. Qualquer administrador pode recusar uma taxa pendente (inclusive quem a criou).

![rejects_currency](https://user-images.githubusercontent.com/85138641/175122090-cec1e8a6-4ed6-4867-86bd-8d279900ac33.png)

#29 