### PR TITLE
Corrige erro de conexão com o e-commerce offline

### DIFF
--- a/app/controllers/admin_backoffice_controller.rb
+++ b/app/controllers/admin_backoffice_controller.rb
@@ -1,8 +1,9 @@
 class AdminBackofficeController < ApplicationController
   rescue_from Errno::ECONNREFUSED, with: :connection_refused
+  rescue_from Faraday::ConnectionFailed, with: :connection_refused 
   before_action :authenticate_admin!
 
   def connection_refused
-    flash[:notice] = :connection_rejected_message
+    flash[:notice] = I18n.t(:connection_rejected_message)
   end
 end


### PR DESCRIPTION
Rescue para realizar qualquer ação do backoffice que faça uma chamada com o faraday para o e-commerce e a aplicação não estiver online
Antes:
![Captura de tela 2022-07-01 210816](https://user-images.githubusercontent.com/104374362/176980225-76082d7a-8fb5-4d97-a974-c48f23e28250.png)

Depois:
![image](https://user-images.githubusercontent.com/104374362/176980255-a7cbd305-879d-4853-9a7e-fa099af2685c.png)
